### PR TITLE
Don't mute the speaker if on desktop

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -53,8 +53,9 @@ class NapTimeSkill(MycroftSkill):
             time.sleep(0.1)
         time.sleep(0.5)  # gives the brightness command time to finish
         self.enclosure.eyes_look("d")
-        self.emitter.emit(Message('mycroft.volume.mute',
-                                  data={"speak_message": False}))
+        if self.config_core.get("enclosure").get("platform", "unknown") != "unknown":
+            self.emitter.emit(Message('mycroft.volume.mute',
+                                      data={"speak_message": False}))
 
 
     def handle_awoken(self, message):

--- a/__init__.py
+++ b/__init__.py
@@ -79,8 +79,9 @@ class NapTimeSkill(MycroftSkill):
         wait_while_speaking()
 
     def awaken(self):
-        self.emitter.emit(Message('mycroft.volume.unmute',
-                                  data={"speak_message": False}))
+        if self.config_core.get("enclosure").get("platform", "unknown") != "unknown":
+            self.emitter.emit(Message('mycroft.volume.unmute',
+                                      data={"speak_message": False}))
         self.sleeping = False
 
     def stop(self):


### PR DESCRIPTION
Desktops have no platform type in their enclosure.  Use this to detect
a desktop install and do not mute the speaker for desktops.

Resolves issue #3 